### PR TITLE
Extract user id from headers for user-specific queries instead of passing manually

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 	implementation 'io.dapr:dapr-sdk-springboot:1.9.0-rc-1'
 	implementation('de.unistuttgart.iste.gits:gits-common') {
 		version {
-			branch = 'auth_headers'
+			branch = 'main'
 		}
 	}
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 	implementation 'io.dapr:dapr-sdk-springboot:1.9.0-rc-1'
 	implementation('de.unistuttgart.iste.gits:gits-common') {
 		version {
-			branch = 'main'
+			branch = 'auth_headers'
 		}
 	}
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/config/RequestHeaderUserInterceptor.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/config/RequestHeaderUserInterceptor.java
@@ -1,0 +1,24 @@
+package de.unistuttgart.iste.gits.media_service.config;
+
+import de.unistuttgart.iste.gits.common.user_handling.RequestHeaderUserProcessor;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.WebGraphQlRequest;
+import org.springframework.graphql.server.WebGraphQlResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * This class is used to add data from the request headers to the GraphQL context.
+ */
+@Configuration
+public class RequestHeaderUserInterceptor implements WebGraphQlInterceptor {
+    @NotNull
+    @Override
+    @SneakyThrows
+    public Mono<WebGraphQlResponse> intercept(@NotNull WebGraphQlRequest request, @NotNull Chain chain) {
+        RequestHeaderUserProcessor.process(request);
+        return chain.next(request);
+    }
+}

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/controller/MediaController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/controller/MediaController.java
@@ -7,7 +7,6 @@ import de.unistuttgart.iste.gits.generated.dto.MediaRecordProgressData;
 import de.unistuttgart.iste.gits.generated.dto.UpdateMediaRecordInput;
 import de.unistuttgart.iste.gits.media_service.service.MediaService;
 import de.unistuttgart.iste.gits.media_service.service.MediaUserProgressDataService;
-import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/controller/MediaController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/controller/MediaController.java
@@ -1,18 +1,17 @@
 package de.unistuttgart.iste.gits.media_service.controller;
 
+import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import de.unistuttgart.iste.gits.generated.dto.CreateMediaRecordInput;
 import de.unistuttgart.iste.gits.generated.dto.MediaRecord;
 import de.unistuttgart.iste.gits.generated.dto.MediaRecordProgressData;
 import de.unistuttgart.iste.gits.generated.dto.UpdateMediaRecordInput;
 import de.unistuttgart.iste.gits.media_service.service.MediaService;
 import de.unistuttgart.iste.gits.media_service.service.MediaUserProgressDataService;
+import graphql.GraphQLContext;
 import graphql.schema.DataFetchingEnvironment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.graphql.data.method.annotation.Argument;
-import org.springframework.graphql.data.method.annotation.MutationMapping;
-import org.springframework.graphql.data.method.annotation.QueryMapping;
-import org.springframework.graphql.data.method.annotation.SchemaMapping;
+import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
 
 import java.util.List;
@@ -56,8 +55,8 @@ public class MediaController {
     }
 
     @SchemaMapping(typeName = "MediaRecord", field = "userProgressData")
-    public MediaRecordProgressData userProgressData(MediaRecord mediaRecord, @Argument UUID userId) {
-        return mediaUserProgressDataService.getUserProgressData(mediaRecord.getId(), userId);
+    public MediaRecordProgressData userProgressData(MediaRecord mediaRecord, @ContextValue LoggedInUser currentUser) {
+        return mediaUserProgressDataService.getUserProgressData(mediaRecord.getId(), currentUser.getId());
     }
 
     @MutationMapping
@@ -84,8 +83,8 @@ public class MediaController {
     }
 
     @MutationMapping
-    public MediaRecord logMediaRecordWorkedOn(@Argument UUID mediaRecordId, @Argument UUID userId) {
-        return mediaUserProgressDataService.logMediaRecordWorkedOn(mediaRecordId, userId);
+    public MediaRecord logMediaRecordWorkedOn(@Argument UUID mediaRecordId, @ContextValue LoggedInUser currentUser) {
+        return mediaUserProgressDataService.logMediaRecordWorkedOn(mediaRecordId, currentUser.getId());
     }
 
     /**

--- a/src/main/resources/graphql/schema.graphqls
+++ b/src/main/resources/graphql/schema.graphqls
@@ -21,7 +21,7 @@ type MediaRecord {
   """
   The progress data of the given user for this medium.
   """
-  userProgressData(userId: UUID!): MediaRecordProgressData!
+  userProgressData: MediaRecordProgressData!
 }
 
 type MediaRecordProgressData {
@@ -85,13 +85,13 @@ type Mutation {
   # Deletes the media record with the given UUID
   deleteMediaRecord(id: UUID!): UUID!
   """
-  Logs that a media has been worked on by a user.
+  Logs that a media has been worked on by the current user.
   See https://gits-enpro.readthedocs.io/en/latest/dev-manuals/gamification/userProgress.html
 
   Possible side effects:
   When all media records of a content have been worked on by a user,
   a user-progress event is emitted for the content.
   """
-  logMediaRecordWorkedOn(mediaRecordId: UUID!, userId: UUID!): MediaRecord!
+  logMediaRecordWorkedOn(mediaRecordId: UUID!): MediaRecord!
 }
 


### PR DESCRIPTION
## Description of changes
Uses the new functionality where user data is transmitted via the headers to get the current user id for queries/mutations depending on it.

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test

Writing automated tests will be done in the next issue.
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
