### PR TITLE
Implementation deletion concept

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/media_service/controller/SubscriptionController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/controller/SubscriptionController.java
@@ -1,0 +1,35 @@
+package de.unistuttgart.iste.gits.media_service.controller;
+
+
+import de.unistuttgart.iste.gits.common.event.ContentChangeEvent;
+import de.unistuttgart.iste.gits.media_service.service.MediaService;
+import io.dapr.Topic;
+import io.dapr.client.domain.CloudEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+
+/**
+ * REST Controller Class listening to a dapr Topic.
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class SubscriptionController {
+
+    private final MediaService mediaService;
+
+    @Topic(name = "content-changes", pubsubName = "gits")
+    @PostMapping(path = "/media-service/content-changes-pubsub")
+    public Mono<Void> updateAssociation(@RequestBody(required = false) CloudEvent<ContentChangeEvent> cloudEvent, @RequestHeader Map<String, String> headers){
+
+            return Mono.fromRunnable( () -> mediaService.removeContentIds(cloudEvent.getData()));
+    }
+
+}


### PR DESCRIPTION
## Description of changes
implemented deletion concept in media service:
media records update their content IDs when content is deleted

  
## How has this been tested?
Please describe the test strategy you followed.

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [X] manual, exploratory test

Manually tested by creating content, linking media records to the content and then deleting the content via course/chapter deletion.
    
## Checklist before requesting a review
- [X] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [X] I have made corresponding changes to the documentation
- [X] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [X] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
