### PR TITLE
Change minio ports to resolve conflict

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - minio
     environment:
       SPRING_DATASOURCE_URL: jdbc:postgresql://database-media:5432/media_service
-      MINIO_URL: http://host.docker.internal:9000
+      MINIO_URL: http://host.docker.internal:3010
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root
       MINIO_ACCESS_KEY: minioadmin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,6 @@ services:
   minio:
     image: quay.io/minio/minio:latest
     command: server --console-address ":9090" /miniodata
-    expose:
-      - "9000"
-      - "9090"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
@@ -24,8 +21,8 @@ services:
       # ../media_service is necessary because otherwise docker-compose overrides the context when merging multiple docker-compose.yml files
       - ./../media_service/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
-      - "9000:9000"
-      - "9090:9090"
+      - "3010:9000"
+      - "3011:9090"
     depends_on:
       - minio
   database-media:

--- a/nginx.conf
+++ b/nginx.conf
@@ -34,7 +34,7 @@ http {
     server {
         listen       9000;
         listen  [::]:9000;
-        server_name  localhost;
+        server_name  minio;
 
         # To allow special characters in headers
         ignore_invalid_headers off;
@@ -64,7 +64,7 @@ http {
     server {
         listen       9090;
         listen  [::]:9090;
-        server_name  localhost;
+        server_name  minio;
 
         # To allow special characters in headers
         ignore_invalid_headers off;

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -9,7 +9,7 @@ spring.sql.init.continue-on-error=true
 spring.jpa.hibernate.ddl-auto=update
 
 # MinIO
-minio.url=http://localhost:9000
+minio.url=http://localhost:3010
 minio.external.url=https://minio.it-rex.ch/
 minio.access.key=minioadmin
 minio.access.secret=minioadmin


### PR DESCRIPTION
## Description of changes
Changes the ports of MinIO to better fit within our port assignments. Necessary to resolve a conflict with the quiz service which got assigned the range 9xxx.

# PLEASE ALSO MERGE THE RELATED WIKI PR IF YOU MERGE THIS https://github.com/IT-REX-Platform/wiki/pull/74
  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [x] manual, exploratory test

It's just a port change.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
