### PR TITLE
added function to automatically remove MediaRecords without file every night

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 | MINIO_URL                  | URL of the Minio server                   | http://localhost:3010                          | http://minio:9000/                                               |
 | minio.external.url         | URL of external minio                     | https://minio.it-rex.ch/                       | https://minio.it-rex.ch/                                         |
 | server.port                | Port on which the application runs        | 3001                                           | 3001                                                             |
+ | mediarecord.delete.cron   | Cron Expression for deleting mediarecords | 0 0 3 * * *                                    | 0 0 3 * * *                                                      |
 
 ### Other properties
 | Name                                      | Description                               | Value in Dev Environment                | Value in Prod Environment               |

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/MediaServiceApplication.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/MediaServiceApplication.java
@@ -10,6 +10,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
@@ -21,6 +22,7 @@ import java.util.List;
  */
 @SpringBootApplication
 @Slf4j
+@EnableScheduling
 public class MediaServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/service/MediaService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/service/MediaService.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.modelmapper.ModelMapper;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.time.*;
@@ -536,6 +537,25 @@ public class MediaService {
             }
 
         }
+    }
 
+    @Scheduled(cron = "${mediarecord.delete.cron}")
+    @SneakyThrows
+    private void deleteMediaRecordsWithoutAFile() {
+        log.info("Running cleanup of MediaRecords");
+        final List<MediaRecordEntity> records = repository.findAll();
+
+        for (final var entity : records) {
+            final Map<String, String> minioVariables = createMinIOVariables(entity);
+            final String bucketId = minioVariables.get(BUCKET_ID);
+            final String filename = minioVariables.get(FILENAME);
+
+            if (!doesObjectExist(filename, bucketId)) {
+                repository.delete(entity);
+            }
+            // publish changes
+            topicPublisher.notifyResourceChange(entity, CrudOperation.DELETE);
+        }
+        log.info("Cleanup completed");
     }
 }

--- a/src/main/java/de/unistuttgart/iste/gits/media_service/service/MediaService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/media_service/service/MediaService.java
@@ -539,6 +539,10 @@ public class MediaService {
         }
     }
 
+    /**
+     * Deletes MediaRecords without a file every night at 3 am.
+     */
+
     @Scheduled(cron = "${mediarecord.delete.cron}")
     @SneakyThrows
     private void deleteMediaRecordsWithoutAFile() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,5 @@ spring.graphql.graphiql.path=/graphiql
 server.port=3001
 dapr.appId=media_service
 dapr.port=3000
+
+mediarecord.delete.cron=0 0 3 * * *

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -8,3 +8,4 @@ minio.url=http://localhost:9000
 minio.external.url=https://minio.it-rex.ch/
 minio.access.key=minioadmin
 minio.access.secret=minioadmin
+mediarecord.delete.cron=0 0 3 * * *


### PR DESCRIPTION

## Description of changes
Added a cronjob to check if mediarecords have a file and if not deletes them, every night at 3 am.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [ ] automated integration test
- [X] manual, exploratory test

Let it ran and delete MediaRecords.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
